### PR TITLE
chore: bump version to v2.9.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ permissions:
 
 jobs:
   hub-ci:
-    uses: "orbitcluster/oc-terraform-module-eks-setup/.github/workflows/main.yml@v2.9.8"
+    uses: "orbitcluster/oc-terraform-module-eks-setup/.github/workflows/main.yml@v2.9.9"
     with:
       tfvar_file_path: "hub.tfvars"
       bucket_name: "oc-backend-hub"
       approvers: "dilipsamanta, mav-sk"
       master_s3_directory: "oc-eks-hub"
-      module_ref: "v2.9.8"
+      module_ref: "v2.9.9"
     secrets: inherit

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -38,12 +38,12 @@ jobs:
 
   hub-destroy:
     needs: validate-input
-    uses: "orbitcluster/oc-terraform-module-eks-setup/.github/workflows/destroy.yml@v2.9.8"
+    uses: "orbitcluster/oc-terraform-module-eks-setup/.github/workflows/destroy.yml@v2.9.9"
     with:
       tfvar_file_path: "hub.tfvars"
       bucket_name: "oc-backend-hub"
       approvers: "dilipsamanta, mav-sk"
       master_s3_directory: "oc-eks-hub"
       component: ${{ github.event.inputs.component }}
-      module_ref: "v2.9.8"
+      module_ref: "v2.9.9"
     secrets: inherit


### PR DESCRIPTION
Updates the version from v2.9.8 to v2.9.9 in ci.yml and destroy.yml.