### PR TITLE
chore: update workflow versions to v2.15.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ permissions:
 
 jobs:
   hub-ci:
-    uses: "orbitcluster/oc-terraform-module-eks-setup/.github/workflows/main.yml@v2.15.0"
+    uses: "orbitcluster/oc-terraform-module-eks-setup/.github/workflows/main.yml@v2.15.1"
     with:
       tfvar_file_path: "hub.tfvars"
       bucket_name: "oc-backend-hub"
       approvers: "dilipsamanta, mav-sk"
       master_s3_directory: "oc-eks-hub"
-      module_ref: "v2.15.0"
+      module_ref: "v2.15.1"
     secrets: inherit

--- a/.github/workflows/destroy.yml
+++ b/.github/workflows/destroy.yml
@@ -38,12 +38,12 @@ jobs:
 
   hub-destroy:
     needs: validate-input
-    uses: "orbitcluster/oc-terraform-module-eks-setup/.github/workflows/destroy.yml@v2.15.0"
+    uses: "orbitcluster/oc-terraform-module-eks-setup/.github/workflows/destroy.yml@v2.15.1"
     with:
       tfvar_file_path: "hub.tfvars"
       bucket_name: "oc-backend-hub"
       approvers: "dilipsamanta, mav-sk"
       master_s3_directory: "oc-eks-hub"
       component: ${{ github.event.inputs.component }}
-      module_ref: "v2.15.0"
+      module_ref: "v2.15.1"
     secrets: inherit


### PR DESCRIPTION
Updates ci.yml and destroy.yml to use version v2.15.1 of the eks-setup workflow.